### PR TITLE
Fixed the `<sections>` displaying as block instead of inline

### DIFF
--- a/pennies/SC/SC.css
+++ b/pennies/SC/SC.css
@@ -25,3 +25,7 @@
   max-width: 100px;
   max-height: 100px;
 }
+
+section {
+  display: inline;
+}


### PR DESCRIPTION
Made it so everything displayed as before

- [x]  I have not plagiarised anything in my edit/entry.
- [x] I have checked that my edit/entry has no spelling/grammar mistakes.
